### PR TITLE
Small correction for #45

### DIFF
--- a/src/linkml_store/api/stores/neo4j/neo4j_database.py
+++ b/src/linkml_store/api/stores/neo4j/neo4j_database.py
@@ -27,7 +27,7 @@ class Neo4jDatabase(Database):
         if handle is None:
             handle = "bolt://localhost:7687/neo4j"
         if handle.startswith("neo4j:"):
-            handle = handle.replace("neo4j:", "bolt:")
+            handle = handle.replace("neo4j:", "bolt:", 1)
         super().__init__(handle=handle, **kwargs)
 
     @property


### PR DESCRIPTION
If the url includes a user:password, the user can be neo4j and then also gets replaced by bolt. Make sure there is only one replacement.
