### PR TITLE
Fix CLI tests: remove deprecated mix_stderr parameter

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,7 +13,7 @@ from tests.conftest import JSON_FILE
 
 @pytest.fixture
 def cli_runner():
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Remove deprecated `mix_stderr=False` parameter from CliRunner fixture
- The `mix_stderr` parameter was removed in click 8.0

## Test plan
- [x] CLI tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)