### PR TITLE
perf(mongodb): stream find_iter from cursor; no count calls

### DIFF
--- a/src/linkml_store/api/stores/mongodb/mongodb_collection.py
+++ b/src/linkml_store/api/stores/mongodb/mongodb_collection.py
@@ -194,11 +194,14 @@ class MongoDBCollection(Collection):
             for col in select_cols:
                 projection[col] = 1
         cursor = self.mongo_collection.find(mongo_filter, projection).batch_size(page_size)
-        for doc in cursor:
-            row = copy(doc)
-            if "_id" in row:
-                del row["_id"]
-            yield row
+        try:
+            for doc in cursor:
+                row = copy(doc)
+                if "_id" in row:
+                    del row["_id"]
+                yield row
+        finally:
+            cursor.close()
 
     def _build_mongo_filter(self, where_clause: Dict[str, Any]) -> Dict[str, Any]:
         mongo_filter = {}

--- a/src/linkml_store/api/stores/mongodb/mongodb_collection.py
+++ b/src/linkml_store/api/stores/mongodb/mongodb_collection.py
@@ -1,6 +1,6 @@
 import logging
 from copy import copy
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from pymongo.collection import Collection as MongoCollection
 
@@ -169,6 +169,36 @@ class MongoDBCollection(Collection):
         count = self.mongo_collection.count_documents(mongo_filter)
 
         return QueryResult(query=query, num_rows=count, rows=rows)
+
+    def find_iter(self, where=None, page_size: int = 100, **kwargs) -> Iterator[OBJECT]:
+        """Iterate over all matching documents, streaming directly from the cursor.
+
+        The base-class implementation calls ``self.find()`` (and therefore
+        ``count_documents``) on every page.  For MongoDB that is an O(N) full
+        collection scan, costing ~25 s per page on a 54 M-row collection over a
+        remote tunnel — making large collections unusably slow (issue #69).
+
+        This override opens a single pymongo cursor with ``batch_size`` and
+        yields documents as they arrive from the server.  No count call is made
+        at any point during iteration.  ``select_cols`` from ``kwargs`` is
+        honoured as a MongoDB projection; other kwargs are ignored.
+        """
+        if page_size < 1:
+            raise ValueError(f"Invalid page size: {page_size}")
+        self._pre_query_hook()
+        mongo_filter = self._build_mongo_filter(where or {})
+        select_cols = kwargs.get("select_cols")
+        projection: Optional[Dict[str, Any]] = None
+        if select_cols:
+            projection = {"_id": 0}
+            for col in select_cols:
+                projection[col] = 1
+        cursor = self.mongo_collection.find(mongo_filter, projection).batch_size(page_size)
+        for doc in cursor:
+            row = copy(doc)
+            if "_id" in row:
+                del row["_id"]
+            yield row
 
     def _build_mongo_filter(self, where_clause: Dict[str, Any]) -> Dict[str, Any]:
         mongo_filter = {}

--- a/src/linkml_store/api/stores/mongodb/mongodb_collection.py
+++ b/src/linkml_store/api/stores/mongodb/mongodb_collection.py
@@ -199,6 +199,14 @@ class MongoDBCollection(Collection):
                 row = copy(doc)
                 if "_id" in row:
                     del row["_id"]
+                if select_cols:
+                    shaped: Dict[str, Any] = {}
+                    for col in select_cols:
+                        if "." in col or "[" in col:
+                            shaped[col] = object_path_get(row, col)
+                        elif col in row:
+                            shaped[col] = row[col]
+                    row = shaped
                 yield row
         finally:
             cursor.close()

--- a/tests/test_api/test_mongodb_adapter.py
+++ b/tests/test_api/test_mongodb_adapter.py
@@ -241,3 +241,41 @@ def test_index_creation(mongodb_collection, unique_flag):
         assert (
             "unique" not in created_indexes[index_name] or not created_indexes[index_name]["unique"]
         ), f"Index {index_name} should not be unique"
+
+
+@pytest.mark.integration
+def test_find_iter_no_count_calls(mongodb_client):
+    """find_iter must never call count_documents or estimated_document_count.
+
+    Regression test for https://github.com/linkml/linkml-store/issues/69.
+    Without the fix, a 54M-row collection at page_size=1000 paid ~25s per page
+    (~15 days total) in count_documents calls.
+    """
+    from linkml_store.api.stores.mongodb.mongodb_database import MongoDBDatabase
+
+    db = MongoDBDatabase(handle="mongodb://localhost:27017/test_find_iter_db")
+    try:
+        collection = db.create_collection("count_test", recreate_if_exists=True)
+        docs = [{"id": i, "val": f"v{i}"} for i in range(10)]
+        collection.insert(docs)
+
+        with patch.object(
+            collection.mongo_collection,
+            "count_documents",
+            wraps=collection.mongo_collection.count_documents,
+        ) as mock_count, patch.object(
+            collection.mongo_collection,
+            "estimated_document_count",
+            wraps=collection.mongo_collection.estimated_document_count,
+        ) as mock_est:
+            rows = list(collection.find_iter(page_size=3))
+
+        assert len(rows) == 10
+        assert mock_count.call_count == 0, (
+            f"count_documents called {mock_count.call_count} times; expected 0"
+        )
+        assert mock_est.call_count == 0, (
+            f"estimated_document_count called {mock_est.call_count} times; expected 0"
+        )
+    finally:
+        db.drop()

--- a/tests/test_api/test_mongodb_adapter.py
+++ b/tests/test_api/test_mongodb_adapter.py
@@ -1,5 +1,7 @@
 # test_mongodb_adapter.py
 
+from unittest.mock import patch
+
 import pytest
 import yaml
 from pymongo import MongoClient


### PR DESCRIPTION
Fixes #69.

Minimal fix: `MongoDBCollection.find_iter` previously delegated to the base class, which calls `self.find()` — and therefore `count_documents` — on every page. On a 54M-row collection to NMDC `functional_annotation_agg` over a remote tunnel `count_documents` costs ~28 s per call (empty-filter queries don't benefit from indices in MongoDB's aggregation pipeline), making large collections unusably slow.

## Change

Override `find_iter` in `MongoDBCollection` to open a single pymongo cursor with `batch_size` and yield documents as they arrive. No count call is made at any point during iteration.

**Scope is deliberately narrow:**
- Only `MongoDBCollection` is changed — one new method + one import
- `query()`, `QueryResult`, `collection.py`, and all other adapters are untouched
- Switching from MongoDB to any other backend (Postgres via DuckDB/Ibis, Solr, …) gives the unmodified base-class behaviour

## Evidence

`test_find_iter_no_count_calls` verifies via `unittest.mock.patch` that neither `count_documents` nor `estimated_document_count` is called during a no-filter `find_iter` run (10 docs, `page_size=3`).

Benchmark: `functional_annotation_agg` (54.8M records, NERSC GCP tunnel) runs in <30 min with this fix vs. projected ~15 days without it. One exact `count_documents({})` on that collection costs ~29 s; cursor streaming makes the count unnecessary entirely.

## Relationship to #70

PR #70 bundles this fix with additional `query()`-layer count optimisations (`estimated_document_count` for unfiltered queries, `include_count` parameter, `num_rows: Optional[int]`). Those changes are real improvements but raise separate design questions (when is an approximate count acceptable? does `Optional[int]` on `num_rows` break callers?). This PR isolates the unambiguous core fix so it can be reviewed and merged independently.