### PR TITLE
fix: define `plt` before use in heatmap export; annotate pyarrow for type checkers

### DIFF
--- a/src/linkml_store/api/stores/dremio/dremio_database.py
+++ b/src/linkml_store/api/stores/dremio/dremio_database.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import parse_qs, urlparse
 
 import pandas as pd
@@ -22,6 +22,12 @@ from linkml_store.api.queries import Query, QueryResult
 from linkml_store.api.stores.dremio.dremio_collection import DremioCollection
 from linkml_store.api.stores.dremio.mappings import get_linkml_type_from_arrow
 from linkml_store.utils.format_utils import Format
+
+if TYPE_CHECKING:
+    # pyarrow is an optional dependency, imported lazily inside the methods that need it.
+    # This import exists only so the "pyarrow.Table" return annotations below resolve for
+    # type checkers; it is not evaluated at runtime and adds no import cost.
+    import pyarrow
 
 logger = logging.getLogger(__name__)
 

--- a/src/linkml_store/plotting/cli.py
+++ b/src/linkml_store/plotting/cli.py
@@ -122,6 +122,7 @@ def heatmap(
     if export_data:
         # For export, reuse the data already loaded for the heatmap instead of loading again
         # This avoids the "I/O operation on closed file" error when input_file is stdin
+        import matplotlib.pyplot as plt
         import pandas as pd
         from matplotlib.axes import Axes
         

--- a/src/linkml_store/plotting/cli.py
+++ b/src/linkml_store/plotting/cli.py
@@ -124,7 +124,6 @@ def heatmap(
         # This avoids the "I/O operation on closed file" error when input_file is stdin
         import matplotlib.pyplot as plt
         import pandas as pd
-        from matplotlib.axes import Axes
         
         # Extract the data directly from the plot
         if hasattr(ax, 'get_figure') and hasattr(ax, 'get_children'):

--- a/tests/test_plotting/test_heatmap_cli_export.py
+++ b/tests/test_plotting/test_heatmap_cli_export.py
@@ -1,0 +1,66 @@
+"""
+Regression test for the heatmap CLI's --export-data path.
+
+The export branch referenced `plt` without importing it in that function, so any
+invocation with --export-data raised `NameError: name 'plt' is not defined`. The
+existing plotting tests call `create_heatmap` and `export_heatmap_data` directly
+and never go through the CLI command, which is why the crash was not caught. See
+https://github.com/linkml/linkml-store/issues/72
+"""
+
+import csv
+from pathlib import Path
+
+import matplotlib
+import pytest
+from click.testing import CliRunner
+
+matplotlib.use("Agg")  # no display in CI
+
+from linkml_store.plotting.cli import plot_cli  # noqa: E402
+
+
+@pytest.fixture
+def input_csv(tmp_path: Path) -> Path:
+    """A small x/y/value table, enough to produce a heatmap with more than one cell."""
+    path = tmp_path / "input.csv"
+    with path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["category_x", "category_y", "value"])
+        for row in [
+            ("A", "X", 1.0),
+            ("B", "X", 2.0),
+            ("A", "Y", 3.0),
+            ("B", "Y", 4.0),
+        ]:
+            writer.writerow(row)
+    return path
+
+
+def test_heatmap_cli_export_data_does_not_crash(input_csv: Path, tmp_path: Path) -> None:
+    """`--export-data` completes and writes the export file."""
+    output_image = tmp_path / "heatmap.png"
+    export_file = tmp_path / "exported.csv"
+
+    result = CliRunner().invoke(
+        plot_cli,
+        [
+            "heatmap",
+            str(input_csv),
+            "-x",
+            "category_x",
+            "-y",
+            "category_y",
+            "-v",
+            "value",
+            "-o",
+            str(output_image),
+            "-e",
+            str(export_file),
+        ],
+    )
+
+    # Surface the real traceback rather than a bare exit code if this regresses.
+    assert result.exit_code == 0, result.output + "\n" + repr(result.exception)
+    assert output_image.exists(), "heatmap image was not written"
+    assert export_file.exists(), "export file was not written"

--- a/tests/test_plotting/test_heatmap_cli_export.py
+++ b/tests/test_plotting/test_heatmap_cli_export.py
@@ -15,7 +15,9 @@ import matplotlib
 import pytest
 from click.testing import CliRunner
 
-matplotlib.use("Agg")  # no display in CI
+# Prefer a headless backend. force=False so that if another test module has already
+# loaded a backend, this leaves it alone rather than switching it session-wide.
+matplotlib.use("Agg", force=False)
 
 from linkml_store.plotting.cli import plot_cli  # noqa: E402
 


### PR DESCRIPTION
Fixes https://github.com/linkml/linkml-store/issues/72.

## One of these is a real crash

`plotting/cli.py:133` uses `plt` inside the `--export-data` branch of the `heatmap` command:

```python
if isinstance(child, plt.matplotlib.collections.QuadMesh):
```

`plt` is never bound there. Every other function in that file does `import matplotlib.pyplot as plt` locally, but `heatmap()` does not, and there is no module-level import. Checked the enclosing scope directly: `heatmap()` spans lines 52 to 172 with no `plt` import, and no module-level binding exists. So any invocation with `--export-data` raises `NameError: name 'plt' is not defined` before it can export anything.

It survived because no test goes through the CLI command. The existing plotting tests call `create_heatmap` and `export_heatmap_data` directly.

This PR adds `tests/test_plotting/test_heatmap_cli_export.py`, which invokes the command through `CliRunner` with `--export-data`. Removing the one-line fix and rerunning gives exactly `NameError("name 'plt' is not defined")`, so the test does catch the regression rather than merely passing.

The fix adds the missing import in that block, matching the lazy-import convention the rest of the file already uses.

## The other three are annotations, not crashes

`dremio_database.py` returns `"pyarrow.Table"` from three methods. `pyarrow` is an optional dependency, imported lazily inside the methods that need it, so the name never resolves for a type checker even though nothing fails at runtime.

Fixed with a `TYPE_CHECKING` import, which resolves the annotations without adding a runtime import or making pyarrow a hard dependency. The comment in the file says so, since a bare `import pyarrow` under `TYPE_CHECKING` looks removable otherwise.

## Checks

Ruff `F821` is now clean across the repository.

Violations in the two touched files go down, not up: `plotting/cli.py` from 26 to 25, `dremio_database.py` from 8 to 5. The new test file is ruff-clean.

`uv.lock` is deliberately untouched. My local test run rewrote it and I reverted that; it is not part of this change.

## Scope

Two source lines of real change plus a `TYPE_CHECKING` block, and one new test.

The other lint issues in these files are left alone. The auto-fixable set from https://github.com/linkml/linkml-store/issues/74 and the CI check from https://github.com/linkml/linkml-store/issues/71 are a separate, mechanical change, and I did not want 96 formatting edits sitting on top of a real bug fix in the same review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
